### PR TITLE
improvement: add HiFimeDIY UAE23 USB DAC to the mixer list

### DIFF
--- a/mixer/mixers.json
+++ b/mixer/mixers.json
@@ -40,6 +40,7 @@
   { "id": 38, "name": "HiFiBerry Digi(Digi+)", "device": "hw:CARD=sndrpihifiberry,DEV=0", "card": "sndrpihifiberry", "dtoverlay": "hifiberry-digi" },
   { "id": 39, "name": "HiFiBerry Digi+ Pro", "device": "hw:CARD=sndrpihifiberry,DEV=0", "card": "sndrpihifiberry", "dtoverlay": "hifiberry-digi-pro" },
   { "id": 40, "name": "HiFiBerry MiniAmp", "device": "hw:CARD=sndrpihifiberry,DEV=0", "card": "sndrpihifiberry", "dtoverlay": "hifiberry-dac" },
+  { "id": 75, "name": "HiFimeDIY UAE23 (USB)", "device": "plughw:CARD=Audio,DEV=0", "card": "Audio", "dtoverlay": "" },
   { "id": 41, "name": "IQaudIO Pi-AMP+", "device": "hw:CARD=IQaudIODAC,DEV=0", "card": "IQaudIODAC", "dtoverlay": "iqaudio-dacplus" },
   { "id": 42, "name": "IQaudIO Pi-DAC", "device": "hw:CARD=IQaudIODAC,DEV=0", "card": "IQaudIODAC", "dtoverlay": "iqaudio-dac" },
   { "id": 43, "name": "IQaudIO Pi-DAC PRO", "device": "hw:CARD=IQaudIODAC,DEV=0", "card": "IQaudIODAC", "dtoverlay": "iqaudio-dacplus" },


### PR DESCRIPTION
Adds the HiFimeDIY UAE23 USB DAC to `mixer/mixers.json`.

```json
{ "id": 75, "name": "HiFimeDIY UAE23 (USB)", "device": "plughw:CARD=Audio,DEV=0", "card": "Audio", "dtoverlay": "" }
```

Like the existing Cambridge Audio DAC100 entry, it uses `plughw` and an empty `dtoverlay` because USB DACs don't need a device tree overlay. Inserted alphabetically between "HiFiBerry MiniAmp" and "IQaudIO Pi-AMP+" so it shows up in the right place in the settings list, which renders the file in order.

Tested on my own hardware — selecting it from the mixer settings gives working playback and volume control.